### PR TITLE
Support postman options language and remove createRequest calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ func main() {
 
     c.AddItemGroup("A folder").AddItem(&postman.Item{
         Name:    "This is a request",
-        Request: postman.CreateRequest("http://www.google.fr", postman.Get),
+        Request: Request{
+			URL: &URL{
+				Raw: "http://www.google.fr",
+			},
+			Method: postman.Get,
+		},
     })
 
     file, err := os.Create("postman_collection.json")
@@ -83,7 +88,12 @@ func main() {
 // Create a simple item.
 item := postman.CreateItem(postman.Item{
     Name:    "A basic request",
-    Request: postman.CreateRequest("http://www.google.fr", postman.Get),
+    Request: Request{
+			URL: &URL{
+				Raw: "http://www.google.fr",
+			},
+			Method: postman.Get,
+		}
 })
 
 // Create a simple folder.
@@ -101,7 +111,12 @@ Part of the `Item`, a `Request` represents an HTTP request.
 
 ```go
 // Basic request
-req := postman.CreateRequest("http://www.google.fr", postman.Get)
+req := Request{
+			URL: &URL{
+				Raw: "http://www.google.fr",
+			},
+			Method: postman.Get,
+		}
 
 // Complex request
 req := postman.Request{

--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ func main() {
 
     c.AddItemGroup("A folder").AddItem(&postman.Item{
         Name:    "This is a request",
-        Request: Request{URL: &URL{Raw: "http://www.google.fr"},Method: postman.Get},
+        Request: Request{
+            URL: &URL{
+                Raw: "http://www.google.fr",
+            },
+            Method: postman.Get,
+        },
     })
 
     file, err := os.Create("postman_collection.json")
@@ -83,7 +88,12 @@ func main() {
 // Create a simple item.
 item := postman.CreateItem(postman.Item{
     Name:    "A basic request",
-    Request: Request{URL: &URL{Raw: "http://www.google.fr"},Method: postman.Get}
+    Request: Request{
+        URL: &URL{
+            Raw: "http://www.google.fr",
+        },
+        Method: postman.Get,
+    }
 })
 
 // Create a simple folder.
@@ -101,7 +111,12 @@ Part of the `Item`, a `Request` represents an HTTP request.
 
 ```go
 // Basic request
-req := Request{URL: &URL{Raw: "http://www.google.fr"},Method: postman.Get}
+req := Request{
+    URL: &URL{
+        Raw: "http://www.google.fr",
+    },
+    Method: postman.Get,
+}
 
 // Complex request
 req := postman.Request{

--- a/README.md
+++ b/README.md
@@ -57,12 +57,7 @@ func main() {
 
     c.AddItemGroup("A folder").AddItem(&postman.Item{
         Name:    "This is a request",
-        Request: Request{
-			URL: &URL{
-				Raw: "http://www.google.fr",
-			},
-			Method: postman.Get,
-		},
+        Request: Request{URL: &URL{Raw: "http://www.google.fr"},Method: postman.Get},
     })
 
     file, err := os.Create("postman_collection.json")
@@ -88,12 +83,7 @@ func main() {
 // Create a simple item.
 item := postman.CreateItem(postman.Item{
     Name:    "A basic request",
-    Request: Request{
-			URL: &URL{
-				Raw: "http://www.google.fr",
-			},
-			Method: postman.Get,
-		}
+    Request: Request{URL: &URL{Raw: "http://www.google.fr"},Method: postman.Get}
 })
 
 // Create a simple folder.
@@ -111,12 +101,7 @@ Part of the `Item`, a `Request` represents an HTTP request.
 
 ```go
 // Basic request
-req := Request{
-			URL: &URL{
-				Raw: "http://www.google.fr",
-			},
-			Method: postman.Get,
-		}
+req := Request{URL: &URL{Raw: "http://www.google.fr"},Method: postman.Get}
 
 // Complex request
 req := postman.Request{

--- a/body.go
+++ b/body.go
@@ -9,4 +9,10 @@ type Body struct {
 	File       interface{} `json:"file,omitempty"`
 	GraphQL    interface{} `json:"graphql,omitempty"`
 	Disabled   bool        `json:"disabled,omitempty"`
+	Options    Raw         `json:"options,omitempty"`
+}
+
+//Raw represents the data of options->language in postman
+type Raw struct {
+	Raw interface{} `json:"raw,omitempty"`
 }

--- a/body.go
+++ b/body.go
@@ -1,6 +1,6 @@
 package postman
 
-//This const represents the language options->language in postman
+//These constants represent the available raw languages.
 const (
 	HTML       string = "html"
 	Javascript string = "javascript"
@@ -11,17 +11,17 @@ const (
 
 // Body represents the data usually contained in the request body.
 type Body struct {
-	Mode       string      `json:"mode"`
-	Raw        string      `json:"raw,omitempty"`
-	URLEncoded interface{} `json:"urlencoded,omitempty"`
-	FormData   interface{} `json:"formdata,omitempty"`
-	File       interface{} `json:"file,omitempty"`
-	GraphQL    interface{} `json:"graphql,omitempty"`
-	Disabled   bool        `json:"disabled,omitempty"`
-	Options    BodyOptions `json:"options,omitempty"`
+	Mode       string       `json:"mode"`
+	Raw        string       `json:"raw,omitempty"`
+	URLEncoded interface{}  `json:"urlencoded,omitempty"`
+	FormData   interface{}  `json:"formdata,omitempty"`
+	File       interface{}  `json:"file,omitempty"`
+	GraphQL    interface{}  `json:"graphql,omitempty"`
+	Disabled   bool         `json:"disabled,omitempty"`
+	Options    *BodyOptions `json:"options,omitempty"`
 }
 
-//BodyOptions represents body raw language option in postman
+//BodyOptions holds body options.
 type BodyOptions struct {
 	Raw BodyOptionsRaw `json:"raw,omitempty"`
 }

--- a/body.go
+++ b/body.go
@@ -1,6 +1,6 @@
 package postman
 
-//These constants represent the available raw languages.
+// These constants represent the available raw languages.
 const (
 	HTML       string = "html"
 	Javascript string = "javascript"
@@ -21,12 +21,12 @@ type Body struct {
 	Options    *BodyOptions `json:"options,omitempty"`
 }
 
-//BodyOptions holds body options.
+// BodyOptions holds body options.
 type BodyOptions struct {
 	Raw BodyOptionsRaw `json:"raw,omitempty"`
 }
 
-//BodyOptionsRaw represents the acutal language to use in postman. (See possible options in the cost above)
+// BodyOptionsRaw represents the acutal language to use in postman. (See possible options in the cost above)
 type BodyOptionsRaw struct {
 	Language string `json:"language,omitempty"`
 }

--- a/body.go
+++ b/body.go
@@ -1,5 +1,14 @@
 package postman
 
+//This const represents the language options->language in postman
+const (
+	HTML       string = "html"
+	Javascript string = "javascript"
+	JSON       string = "json"
+	Text       string = "text"
+	XML        string = "xml"
+)
+
 // Body represents the data usually contained in the request body.
 type Body struct {
 	Mode       string      `json:"mode"`
@@ -9,10 +18,15 @@ type Body struct {
 	File       interface{} `json:"file,omitempty"`
 	GraphQL    interface{} `json:"graphql,omitempty"`
 	Disabled   bool        `json:"disabled,omitempty"`
-	Options    Raw         `json:"options,omitempty"`
+	Options    BodyOptions `json:"options,omitempty"`
 }
 
-//Raw represents the data of options->language in postman
-type Raw struct {
-	Raw interface{} `json:"raw,omitempty"`
+//BodyOptions represents body raw language option in postman
+type BodyOptions struct {
+	Raw BodyOptionsRaw `json:"raw,omitempty"`
+}
+
+//BodyOptionsRaw represents the acutal language to use in postman. (See possible options in the cost above)
+type BodyOptionsRaw struct {
+	Language string `json:"language,omitempty"`
 }

--- a/collection_test.go
+++ b/collection_test.go
@@ -74,9 +74,9 @@ func (suite *CollectionTestSuite) SetupTest() {
 						},
 					},
 					Body: &Body{
-						Mode: "raw",
-						Raw:  "{\"aKey\":\"a-value\"}",
-						//						Options: Raw{map[string]interface{}{"language": "json"}},
+						Mode:    "raw",
+						Raw:     "{\"aKey\":\"a-value\"}",
+						Options: BodyOptions{BodyOptionsRaw{Language: "json"}},
 					},
 				},
 			},
@@ -248,12 +248,12 @@ func (suite *CollectionTestSuite) TestParseCollection() {
 			suite.V200Collection,
 			nil,
 		},
-		// {
-		// 	"v2.1.0 collection",
-		// 	"testdata/collection_v2.1.0.json",
-		// 	suite.V210Collection,
-		// 	nil,
-		// },
+		{
+			"v2.1.0 collection",
+			"testdata/collection_v2.1.0.json",
+			suite.V210Collection,
+			nil,
+		},
 	}
 
 	for _, tc := range cases {

--- a/collection_test.go
+++ b/collection_test.go
@@ -76,6 +76,7 @@ func (suite *CollectionTestSuite) SetupTest() {
 					Body: &Body{
 						Mode: "raw",
 						Raw:  "{\"aKey\":\"a-value\"}",
+						//						Options: Raw{map[string]interface{}{"language": "json"}},
 					},
 				},
 			},
@@ -162,8 +163,9 @@ func (suite *CollectionTestSuite) SetupTest() {
 						},
 					},
 					Body: &Body{
-						Mode: "raw",
-						Raw:  "{\"aKey\":\"a-value\"}",
+						Mode:    "raw",
+						Raw:     "{\"aKey\":\"a-value\"}",
+						Options: BodyOptions{BodyOptionsRaw{Language: "json"}},
 					},
 				},
 			},
@@ -246,19 +248,18 @@ func (suite *CollectionTestSuite) TestParseCollection() {
 			suite.V200Collection,
 			nil,
 		},
-		{
-			"v2.1.0 collection",
-			"testdata/collection_v2.1.0.json",
-			suite.V210Collection,
-			nil,
-		},
+		// {
+		// 	"v2.1.0 collection",
+		// 	"testdata/collection_v2.1.0.json",
+		// 	suite.V210Collection,
+		// 	nil,
+		// },
 	}
 
 	for _, tc := range cases {
 		file, _ := os.Open(tc.testFile)
 
 		c, err := ParseCollection(file)
-
 		assert.Equal(suite.T(), tc.expectedError, err, tc.scenario)
 		assert.Equal(suite.T(), tc.expectedCollection, c, tc.scenario)
 	}

--- a/request.go
+++ b/request.go
@@ -21,16 +21,6 @@ type Request struct {
 // mRequest is used for marshalling/unmarshalling.
 type mRequest Request
 
-// CreateRequest creates a new request.
-func CreateRequest(u string, m method) *Request {
-	return &Request{
-		URL: &URL{
-			Raw: u,
-		},
-		Method: m,
-	}
-}
-
 // MarshalJSON returns the JSON encoding of a Request.
 // If the Request only contains an URL with the Get HTTP method, it is returned as a string.
 func (r Request) MarshalJSON() ([]byte, error) {

--- a/request_test.go
+++ b/request_test.go
@@ -66,7 +66,7 @@ func TestRequestMarshalJSON(t *testing.T) {
 				Body: &Body{
 					Mode:    "raw",
 					Raw:     "raw-content",
-					Options: Raw{map[string]interface{}{"language": "json"}},
+					Options: BodyOptions{BodyOptionsRaw{Language: "json"}},
 				},
 			},
 			"{\"url\":\"http://www.google.fr\",\"method\":\"POST\",\"body\":{\"mode\":\"raw\",\"raw\":\"raw-content\",\"options\":{\"raw\":{\"language\":\"json\"}}}}",
@@ -84,7 +84,7 @@ func TestRequestMarshalJSON(t *testing.T) {
 					Raw:  "raw-content",
 				},
 			},
-			"{\"url\":{\"raw\":\"http://www.google.fr\"},\"method\":\"POST\",\"body\":{\"mode\":\"raw\",\"raw\":\"raw-content\"}}",
+			"{\"url\":{\"raw\":\"http://www.google.fr\"},\"method\":\"POST\",\"body\":{\"mode\":\"raw\",\"raw\":\"raw-content\"qq}}",
 		},
 	}
 
@@ -160,7 +160,7 @@ func TestSimplePOSTItem(t *testing.T) {
 		Host:     []string{"test", "com"},
 	}
 
-	headers := []*Header{&Header{
+	headers := []*Header{{
 		Key:   "h1",
 		Value: "h1-value",
 	}}
@@ -168,7 +168,7 @@ func TestSimplePOSTItem(t *testing.T) {
 	pBody := Body{
 		Mode:    "raw",
 		Raw:     "{\"a\":\"1234\",\"b\":123}",
-		Options: Raw{map[string]interface{}{"language": "json"}},
+		Options: BodyOptions{BodyOptionsRaw{Language: "json"}},
 	}
 
 	pReq := Request{

--- a/request_test.go
+++ b/request_test.go
@@ -2,7 +2,6 @@ package postman
 
 import (
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,7 +65,7 @@ func TestRequestMarshalJSON(t *testing.T) {
 				Body: &Body{
 					Mode:    "raw",
 					Raw:     "raw-content",
-					Options: BodyOptions{BodyOptionsRaw{Language: "json"}},
+					Options: &BodyOptions{BodyOptionsRaw{Language: "json"}},
 				},
 			},
 			"{\"url\":\"http://www.google.fr\",\"method\":\"POST\",\"body\":{\"mode\":\"raw\",\"raw\":\"raw-content\",\"options\":{\"raw\":{\"language\":\"json\"}}}}",
@@ -84,7 +83,7 @@ func TestRequestMarshalJSON(t *testing.T) {
 					Raw:  "raw-content",
 				},
 			},
-			"{\"url\":{\"raw\":\"http://www.google.fr\"},\"method\":\"POST\",\"body\":{\"mode\":\"raw\",\"raw\":\"raw-content\"qq}}",
+			"{\"url\":{\"raw\":\"http://www.google.fr\"},\"method\":\"POST\",\"body\":{\"mode\":\"raw\",\"raw\":\"raw-content\"}}",
 		},
 	}
 
@@ -143,111 +142,4 @@ func TestRequestUnmarshalJSON(t *testing.T) {
 		assert.Equal(t, tc.expectedRequest, r, tc.scenario)
 		assert.Equal(t, tc.expectedError, err, tc.scenario)
 	}
-}
-
-func TestSimplePOSTItem(t *testing.T) {
-	c := CreateCollection("Test Collection", "My Test Collection")
-
-	file, err := os.Create("postman_collection.json")
-	assert.Nil(t, err)
-	assert.NotNil(t, file)
-
-	defer file.Close()
-
-	pURL := URL{
-		Raw:      "https://test.com",
-		Protocol: "https",
-		Host:     []string{"test", "com"},
-	}
-
-	headers := []*Header{{
-		Key:   "h1",
-		Value: "h1-value",
-	}}
-
-	pBody := Body{
-		Mode:    "raw",
-		Raw:     "{\"a\":\"1234\",\"b\":123}",
-		Options: BodyOptions{BodyOptionsRaw{Language: "json"}},
-	}
-
-	pReq := Request{
-		Method: Post,
-		URL:    &pURL,
-		Header: headers,
-		Body:   &pBody,
-	}
-
-	cr := Request{
-		Method: Post,
-		URL:    &pURL,
-		Header: pReq.Header,
-		Body:   pReq.Body,
-	}
-
-	item := CreateItem(Item{
-		Name:    "Test-POST",
-		Request: &cr,
-	})
-
-	c.AddItemGroup("grp1").AddItem(item)
-
-	err = c.Write(file, V210)
-	assert.Nil(t, err)
-
-	err = os.Remove("postman_collection.json")
-	assert.Nil(t, err)
-}
-
-func TestSimpleGETItem(t *testing.T) {
-	c := CreateCollection("Test Collection", "My Test Collection")
-
-	file, err := os.Create("postman_collection.json")
-	assert.Nil(t, err)
-	assert.NotNil(t, file)
-
-	defer file.Close()
-
-	m1 := map[string]interface{}{"key": "param1", "value": "value1"}
-	m2 := map[string]interface{}{"key": "param2", "value": "value2"}
-
-	var arrMaps []map[string]interface{}
-	arrMaps = append(arrMaps, m1)
-	arrMaps = append(arrMaps, m2)
-
-	pURL := URL{
-		Raw:      "https://test.com?a=3",
-		Protocol: "https",
-		Host:     []string{"test", "com"},
-		Query:    arrMaps,
-	}
-
-	headers := []*Header{}
-	headers = append(headers, &Header{
-		Key:   "h1",
-		Value: "h1-value",
-	})
-	headers = append(headers, &Header{
-		Key:   "h2",
-		Value: "h2-value",
-	})
-
-	pReq := Request{
-		Method: Get,
-		URL:    &pURL,
-		Header: headers,
-	}
-
-	item := CreateItem(Item{
-		Name:    "Test-GET",
-		Request: &pReq,
-	})
-
-	c.AddItemGroup("grp1").AddItem(item)
-
-	err = c.Write(file, V210)
-	assert.Nil(t, err)
-
-	err = os.Remove("postman_collection.json")
-	assert.Nil(t, err)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -7,36 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateRequest(t *testing.T) {
-	cases := []struct {
-		method          method
-		url             string
-		expectedRequest *Request
-	}{
-		{
-			Get,
-			"an-url",
-			&Request{
-				Method: Get,
-				URL: &URL{
-					Raw: "an-url",
-				},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		req := &Request{
-			URL: &URL{
-				Raw: tc.url,
-			},
-			Method: tc.method,
-		}
-
-		assert.Equal(t, tc.expectedRequest, req)
-	}
-}
-
 func TestRequestMarshalJSON(t *testing.T) {
 	cases := []struct {
 		scenario       string

--- a/request_test.go
+++ b/request_test.go
@@ -2,6 +2,7 @@ package postman
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,12 @@ func TestCreateRequest(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		req := CreateRequest(tc.url, tc.method)
+		req := &Request{
+			URL: &URL{
+				Raw: tc.url,
+			},
+			Method: tc.method,
+		}
 
 		assert.Equal(t, tc.expectedRequest, req)
 	}
@@ -58,11 +64,12 @@ func TestRequestMarshalJSON(t *testing.T) {
 					version: V200,
 				},
 				Body: &Body{
-					Mode: "raw",
-					Raw:  "raw-content",
+					Mode:    "raw",
+					Raw:     "raw-content",
+					Options: Raw{map[string]interface{}{"language": "json"}},
 				},
 			},
-			"{\"url\":\"http://www.google.fr\",\"method\":\"POST\",\"body\":{\"mode\":\"raw\",\"raw\":\"raw-content\"}}",
+			"{\"url\":\"http://www.google.fr\",\"method\":\"POST\",\"body\":{\"mode\":\"raw\",\"raw\":\"raw-content\",\"options\":{\"raw\":{\"language\":\"json\"}}}}",
 		},
 		{
 			"Successfully marshalling a Request as an object (v2.1.0)",
@@ -136,4 +143,111 @@ func TestRequestUnmarshalJSON(t *testing.T) {
 		assert.Equal(t, tc.expectedRequest, r, tc.scenario)
 		assert.Equal(t, tc.expectedError, err, tc.scenario)
 	}
+}
+
+func TestSimplePOSTItem(t *testing.T) {
+	c := CreateCollection("Test Collection", "My Test Collection")
+
+	file, err := os.Create("postman_collection.json")
+	assert.Nil(t, err)
+	assert.NotNil(t, file)
+
+	defer file.Close()
+
+	pURL := URL{
+		Raw:      "https://test.com",
+		Protocol: "https",
+		Host:     []string{"test", "com"},
+	}
+
+	headers := []*Header{&Header{
+		Key:   "h1",
+		Value: "h1-value",
+	}}
+
+	pBody := Body{
+		Mode:    "raw",
+		Raw:     "{\"a\":\"1234\",\"b\":123}",
+		Options: Raw{map[string]interface{}{"language": "json"}},
+	}
+
+	pReq := Request{
+		Method: Post,
+		URL:    &pURL,
+		Header: headers,
+		Body:   &pBody,
+	}
+
+	cr := Request{
+		Method: Post,
+		URL:    &pURL,
+		Header: pReq.Header,
+		Body:   pReq.Body,
+	}
+
+	item := CreateItem(Item{
+		Name:    "Test-POST",
+		Request: &cr,
+	})
+
+	c.AddItemGroup("grp1").AddItem(item)
+
+	err = c.Write(file, V210)
+	assert.Nil(t, err)
+
+	err = os.Remove("postman_collection.json")
+	assert.Nil(t, err)
+}
+
+func TestSimpleGETItem(t *testing.T) {
+	c := CreateCollection("Test Collection", "My Test Collection")
+
+	file, err := os.Create("postman_collection.json")
+	assert.Nil(t, err)
+	assert.NotNil(t, file)
+
+	defer file.Close()
+
+	m1 := map[string]interface{}{"key": "param1", "value": "value1"}
+	m2 := map[string]interface{}{"key": "param2", "value": "value2"}
+
+	var arrMaps []map[string]interface{}
+	arrMaps = append(arrMaps, m1)
+	arrMaps = append(arrMaps, m2)
+
+	pURL := URL{
+		Raw:      "https://test.com?a=3",
+		Protocol: "https",
+		Host:     []string{"test", "com"},
+		Query:    arrMaps,
+	}
+
+	headers := []*Header{}
+	headers = append(headers, &Header{
+		Key:   "h1",
+		Value: "h1-value",
+	})
+	headers = append(headers, &Header{
+		Key:   "h2",
+		Value: "h2-value",
+	})
+
+	pReq := Request{
+		Method: Get,
+		URL:    &pURL,
+		Header: headers,
+	}
+
+	item := CreateItem(Item{
+		Name:    "Test-GET",
+		Request: &pReq,
+	})
+
+	c.AddItemGroup("grp1").AddItem(item)
+
+	err = c.Write(file, V210)
+	assert.Nil(t, err)
+
+	err = os.Remove("postman_collection.json")
+	assert.Nil(t, err)
 }

--- a/testdata/collection_v2.0.0.json
+++ b/testdata/collection_v2.0.0.json
@@ -43,7 +43,12 @@
                 ],
                 "body": {
                     "mode": "raw",
-                    "raw": "{\"aKey\":\"a-value\"}"
+                    "raw": "{\"aKey\":\"a-value\"}",
+                    "options": {
+                        "raw": {
+                            "language": "json"
+                        }
+                    }
                 }
             }
         },

--- a/testdata/collection_v2.0.0.json
+++ b/testdata/collection_v2.0.0.json
@@ -44,7 +44,11 @@
                 "body": {
                     "mode": "raw",
                     "raw": "{\"aKey\":\"a-value\"}",
-                    "options": "{\"raw\": {\"language\": \"json\"}"
+                    "options": {
+                        "raw": {
+                            "language": "json"
+                        }
+                    }
                 }
             }
         },

--- a/testdata/collection_v2.0.0.json
+++ b/testdata/collection_v2.0.0.json
@@ -44,11 +44,7 @@
                 "body": {
                     "mode": "raw",
                     "raw": "{\"aKey\":\"a-value\"}",
-                    "options": {
-                        "raw": {
-                            "language": "json"
-                        }
-                    }
+                    "options": "{\"raw\": {\"language\": \"json\"}"
                 }
             }
         },

--- a/testdata/collection_v2.1.0.json
+++ b/testdata/collection_v2.1.0.json
@@ -66,7 +66,11 @@
                 "body": {
                     "mode": "raw",
                     "raw": "{\"aKey\":\"a-value\"}",
-                    "options": "{\"raw\": {\"language\": \"json\"}"
+                    "options": {
+                        "raw": {
+                            "language": "json"
+                        }
+                    }
                 }
             }
         },

--- a/testdata/collection_v2.1.0.json
+++ b/testdata/collection_v2.1.0.json
@@ -65,7 +65,8 @@
                 ],
                 "body": {
                     "mode": "raw",
-                    "raw": "{\"aKey\":\"a-value\"}"
+                    "raw": "{\"aKey\":\"a-value\"}",
+                    "options": "{\"raw\": {\"language\": \"json\"}"
                 }
             }
         },


### PR DESCRIPTION
Add raw options to support JSON/Text etc on postman
Removed the CreateRequest cuz it not needed.
In the original implementation, the host + method never used and since we can be declared the struct we don't need a function for it.