### PR TITLE
Collection Auth and Item Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ func main() {
 
     c.AddItemGroup("A folder").AddItem(&postman.Item{
         Name:    "This is a request",
-        Request: postman.CreateRequest("http://www.google.fr", postman.Get),
+        Request: Request{
+            URL: &URL{
+                Raw: "http://www.google.fr",
+            },
+            Method: postman.Get,
+        },
     })
 
     file, err := os.Create("postman_collection.json")
@@ -83,7 +88,12 @@ func main() {
 // Create a simple item.
 item := postman.CreateItem(postman.Item{
     Name:    "A basic request",
-    Request: postman.CreateRequest("http://www.google.fr", postman.Get),
+    Request: Request{
+        URL: &URL{
+            Raw: "http://www.google.fr",
+        },
+        Method: postman.Get,
+    }
 })
 
 // Create a simple folder.
@@ -101,7 +111,12 @@ Part of the `Item`, a `Request` represents an HTTP request.
 
 ```go
 // Basic request
-req := postman.CreateRequest("http://www.google.fr", postman.Get)
+req := Request{
+    URL: &URL{
+        Raw: "http://www.google.fr",
+    },
+    Method: postman.Get,
+}
 
 // Complex request
 req := postman.Request{

--- a/body.go
+++ b/body.go
@@ -1,12 +1,32 @@
 package postman
 
+// These constants represent the available raw languages.
+const (
+	HTML       string = "html"
+	Javascript string = "javascript"
+	JSON       string = "json"
+	Text       string = "text"
+	XML        string = "xml"
+)
+
 // Body represents the data usually contained in the request body.
 type Body struct {
-	Mode       string      `json:"mode"`
-	Raw        string      `json:"raw,omitempty"`
-	URLEncoded interface{} `json:"urlencoded,omitempty"`
-	FormData   interface{} `json:"formdata,omitempty"`
-	File       interface{} `json:"file,omitempty"`
-	GraphQL    interface{} `json:"graphql,omitempty"`
-	Disabled   bool        `json:"disabled,omitempty"`
+	Mode       string       `json:"mode"`
+	Raw        string       `json:"raw,omitempty"`
+	URLEncoded interface{}  `json:"urlencoded,omitempty"`
+	FormData   interface{}  `json:"formdata,omitempty"`
+	File       interface{}  `json:"file,omitempty"`
+	GraphQL    interface{}  `json:"graphql,omitempty"`
+	Disabled   bool         `json:"disabled,omitempty"`
+	Options    *BodyOptions `json:"options,omitempty"`
+}
+
+// BodyOptions holds body options.
+type BodyOptions struct {
+	Raw BodyOptionsRaw `json:"raw,omitempty"`
+}
+
+// BodyOptionsRaw represents the acutal language to use in postman. (See possible options in the cost above)
+type BodyOptionsRaw struct {
+	Language string `json:"language,omitempty"`
 }

--- a/collection.go
+++ b/collection.go
@@ -25,6 +25,7 @@ type Info struct {
 
 // Collection represents a Postman Collection.
 type Collection struct {
+	Auth      Auth        `json:"auth"`
 	Info      Info        `json:"info"`
 	Items     []*Items    `json:"item"`
 	Variables []*Variable `json:"variable,omitempty"`

--- a/collection_test.go
+++ b/collection_test.go
@@ -74,8 +74,9 @@ func (suite *CollectionTestSuite) SetupTest() {
 						},
 					},
 					Body: &Body{
-						Mode: "raw",
-						Raw:  "{\"aKey\":\"a-value\"}",
+						Mode:    "raw",
+						Raw:     "{\"aKey\":\"a-value\"}",
+						Options: &BodyOptions{BodyOptionsRaw{Language: "json"}},
 					},
 				},
 			},
@@ -162,8 +163,9 @@ func (suite *CollectionTestSuite) SetupTest() {
 						},
 					},
 					Body: &Body{
-						Mode: "raw",
-						Raw:  "{\"aKey\":\"a-value\"}",
+						Mode:    "raw",
+						Raw:     "{\"aKey\":\"a-value\"}",
+						Options: &BodyOptions{BodyOptionsRaw{Language: "json"}},
 					},
 				},
 			},
@@ -258,7 +260,6 @@ func (suite *CollectionTestSuite) TestParseCollection() {
 		file, _ := os.Open(tc.testFile)
 
 		c, err := ParseCollection(file)
-
 		assert.Equal(suite.T(), tc.expectedError, err, tc.scenario)
 		assert.Equal(suite.T(), tc.expectedCollection, c, tc.scenario)
 	}
@@ -292,4 +293,111 @@ func (suite *CollectionTestSuite) TestWriteCollection() {
 
 		assert.Equal(suite.T(), string(file), fmt.Sprintf("%s\n", buf.String()), tc.scenario)
 	}
+}
+
+func (suite *CollectionTestSuite) TestSimplePOSTItem() {
+	c := CreateCollection("Test Collection", "My Test Collection")
+
+	file, err := os.Create("postman_collection.json")
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), file)
+
+	defer file.Close()
+
+	pURL := URL{
+		Raw:      "https://test.com",
+		Protocol: "https",
+		Host:     []string{"test", "com"},
+	}
+
+	headers := []*Header{{
+		Key:   "h1",
+		Value: "h1-value",
+	}}
+
+	pBody := Body{
+		Mode:    "raw",
+		Raw:     "{\"a\":\"1234\",\"b\":123}",
+		Options: &BodyOptions{BodyOptionsRaw{Language: "json"}},
+	}
+
+	pReq := Request{
+		Method: Post,
+		URL:    &pURL,
+		Header: headers,
+		Body:   &pBody,
+	}
+
+	cr := Request{
+		Method: Post,
+		URL:    &pURL,
+		Header: pReq.Header,
+		Body:   pReq.Body,
+	}
+
+	item := CreateItem(Item{
+		Name:    "Test-POST",
+		Request: &cr,
+	})
+
+	c.AddItemGroup("grp1").AddItem(item)
+
+	err = c.Write(file, V210)
+	assert.Nil(suite.T(), err)
+
+	err = os.Remove("postman_collection.json")
+	assert.Nil(suite.T(), err)
+}
+
+func (suite *CollectionTestSuite) TestSimpleGETItem() {
+	c := CreateCollection("Test Collection", "My Test Collection")
+
+	file, err := os.Create("postman_collection.json")
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), file)
+
+	defer file.Close()
+
+	m1 := map[string]interface{}{"key": "param1", "value": "value1"}
+	m2 := map[string]interface{}{"key": "param2", "value": "value2"}
+
+	var arrMaps []map[string]interface{}
+	arrMaps = append(arrMaps, m1)
+	arrMaps = append(arrMaps, m2)
+
+	pURL := URL{
+		Raw:      "https://test.com?a=3",
+		Protocol: "https",
+		Host:     []string{"test", "com"},
+		Query:    arrMaps,
+	}
+
+	headers := []*Header{}
+	headers = append(headers, &Header{
+		Key:   "h1",
+		Value: "h1-value",
+	})
+	headers = append(headers, &Header{
+		Key:   "h2",
+		Value: "h2-value",
+	})
+
+	pReq := Request{
+		Method: Get,
+		URL:    &pURL,
+		Header: headers,
+	}
+
+	item := CreateItem(Item{
+		Name:    "Test-GET",
+		Request: &pReq,
+	})
+
+	c.AddItemGroup("grp1").AddItem(item)
+
+	err = c.Write(file, V210)
+	assert.Nil(suite.T(), err)
+
+	err = os.Remove("postman_collection.json")
+	assert.Nil(suite.T(), err)
 }

--- a/items.go
+++ b/items.go
@@ -12,9 +12,9 @@ type Items struct {
 	Event                   interface{} `json:"event,omitempty"`
 	ProtocolProfileBehavior interface{} `json:"protocolProfileBehavior,omitempty"`
 	// Fields specific to Item
-	ID       string      `json:"id,omitempty"`
-	Request  *Request    `json:"request,omitempty"`
-	Response []*Response `json:"response,omitempty"`
+	ID        string      `json:"id,omitempty"`
+	Request   *Request    `json:"request,omitempty"`
+	Responses []*Response `json:"response,omitempty"`
 	// Fields specific to ItemGroup
 	Items []*Items `json:"item"`
 	Auth  *Auth    `json:"auth,omitempty"`
@@ -29,7 +29,7 @@ type Item struct {
 	ProtocolProfileBehavior interface{} `json:"protocolProfileBehavior,omitempty"`
 	ID                      string      `json:"id,omitempty"`
 	Request                 *Request    `json:"request,omitempty"`
-	Response                []*Response `json:"response,omitempty"`
+	Responses               []*Response `json:"response,omitempty"`
 }
 
 // A ItemGroup is an ordered set of requests.
@@ -53,7 +53,7 @@ func CreateItem(i Item) *Items {
 		ProtocolProfileBehavior: i.ProtocolProfileBehavior,
 		ID:                      i.ID,
 		Request:                 i.Request,
-		Response:                i.Response,
+		Responses:               i.Responses,
 	}
 }
 
@@ -119,6 +119,6 @@ func (i Items) MarshalJSON() ([]byte, error) {
 		ProtocolProfileBehavior: i.ProtocolProfileBehavior,
 		ID:                      i.ID,
 		Request:                 i.Request,
-		Response:                i.Response,
+		Responses:               i.Responses,
 	})
 }

--- a/items.go
+++ b/items.go
@@ -14,7 +14,7 @@ type Items struct {
 	// Fields specific to Item
 	ID       string      `json:"id,omitempty"`
 	Request  *Request    `json:"request,omitempty"`
-	Response interface{} `json:"response,omitempty"`
+	Response []*Response `json:"response,omitempty"`
 	// Fields specific to ItemGroup
 	Items []*Items `json:"item"`
 	Auth  *Auth    `json:"auth,omitempty"`
@@ -29,7 +29,7 @@ type Item struct {
 	ProtocolProfileBehavior interface{} `json:"protocolProfileBehavior,omitempty"`
 	ID                      string      `json:"id,omitempty"`
 	Request                 *Request    `json:"request,omitempty"`
-	Response                interface{} `json:"response,omitempty"`
+	Response                []*Response `json:"response,omitempty"`
 }
 
 // A ItemGroup is an ordered set of requests.

--- a/items_test.go
+++ b/items_test.go
@@ -145,7 +145,11 @@ func TestCreateItem(t *testing.T) {
 				Raw: "http://www.google.fr",
 			},
 		},
-		Response: "a-response",
+		Response: []*Response{
+			{
+				Name: "a-response",
+			},
+		},
 	})
 
 	assert.Equal(
@@ -167,7 +171,11 @@ func TestCreateItem(t *testing.T) {
 					Raw: "http://www.google.fr",
 				},
 			},
-			Response: "a-response",
+			Response: []*Response{
+				{
+					Name: "a-response",
+				},
+			},
 		},
 		c,
 	)

--- a/items_test.go
+++ b/items_test.go
@@ -145,7 +145,7 @@ func TestCreateItem(t *testing.T) {
 				Raw: "http://www.google.fr",
 			},
 		},
-		Response: []*Response{
+		Responses: []*Response{
 			{
 				Name: "a-response",
 			},
@@ -171,7 +171,7 @@ func TestCreateItem(t *testing.T) {
 					Raw: "http://www.google.fr",
 				},
 			},
-			Response: []*Response{
+			Responses: []*Response{
 				{
 					Name: "a-response",
 				},

--- a/request.go
+++ b/request.go
@@ -21,16 +21,6 @@ type Request struct {
 // mRequest is used for marshalling/unmarshalling.
 type mRequest Request
 
-// CreateRequest creates a new request.
-func CreateRequest(u string, m method) *Request {
-	return &Request{
-		URL: &URL{
-			Raw: u,
-		},
-		Method: m,
-	}
-}
-
 // MarshalJSON returns the JSON encoding of a Request.
 // If the Request only contains an URL with the Get HTTP method, it is returned as a string.
 func (r Request) MarshalJSON() ([]byte, error) {

--- a/request_test.go
+++ b/request_test.go
@@ -7,31 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateRequest(t *testing.T) {
-	cases := []struct {
-		method          method
-		url             string
-		expectedRequest *Request
-	}{
-		{
-			Get,
-			"an-url",
-			&Request{
-				Method: Get,
-				URL: &URL{
-					Raw: "an-url",
-				},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		req := CreateRequest(tc.url, tc.method)
-
-		assert.Equal(t, tc.expectedRequest, req)
-	}
-}
-
 func TestRequestMarshalJSON(t *testing.T) {
 	cases := []struct {
 		scenario       string
@@ -58,11 +33,12 @@ func TestRequestMarshalJSON(t *testing.T) {
 					version: V200,
 				},
 				Body: &Body{
-					Mode: "raw",
-					Raw:  "raw-content",
+					Mode:    "raw",
+					Raw:     "raw-content",
+					Options: &BodyOptions{BodyOptionsRaw{Language: "json"}},
 				},
 			},
-			"{\"url\":\"http://www.google.fr\",\"method\":\"POST\",\"body\":{\"mode\":\"raw\",\"raw\":\"raw-content\"}}",
+			"{\"url\":\"http://www.google.fr\",\"method\":\"POST\",\"body\":{\"mode\":\"raw\",\"raw\":\"raw-content\",\"options\":{\"raw\":{\"language\":\"json\"}}}}",
 		},
 		{
 			"Successfully marshalling a Request as an object (v2.1.0)",

--- a/response.go
+++ b/response.go
@@ -1,0 +1,12 @@
+package postman
+
+// A Response represents an HTTP request and response.
+type Response struct {
+	Name            string    `json:"name"`
+	OriginalRequest *Request  `json:"originalRequest"`
+	Status          string    `json:"status,omitempty"`
+	Code            int       `json:"code,omitempty"`
+	PreviewLanguage string    `json:"_postman_previewlanguage,omitempty"`
+	Header          []*Header `json:"header,omitempty"`
+	Body            string    `json:"body,omitempty"`
+}

--- a/testdata/collection_v2.0.0.json
+++ b/testdata/collection_v2.0.0.json
@@ -43,7 +43,12 @@
                 ],
                 "body": {
                     "mode": "raw",
-                    "raw": "{\"aKey\":\"a-value\"}"
+                    "raw": "{\"aKey\":\"a-value\"}",
+                    "options": {
+                        "raw": {
+                            "language": "json"
+                        }
+                    }
                 }
             }
         },

--- a/testdata/collection_v2.1.0.json
+++ b/testdata/collection_v2.1.0.json
@@ -65,7 +65,12 @@
                 ],
                 "body": {
                     "mode": "raw",
-                    "raw": "{\"aKey\":\"a-value\"}"
+                    "raw": "{\"aKey\":\"a-value\"}",
+                    "options": {
+                        "raw": {
+                            "language": "json"
+                        }
+                    }
                 }
             }
         },

--- a/testdata/collection_v2.1.0.json
+++ b/testdata/collection_v2.1.0.json
@@ -1,4 +1,5 @@
 {
+    "auth": {},
     "info": {
         "name": "Go Collection",
         "description": "Awesome description",


### PR DESCRIPTION
This adds collection level auth and item responses.

Based on the 2.0 spec at https://schema.getpostman.com/collection/json/v2.0.0/draft-04/collection.json we can see:

- `.properties.auth` which represents collection wide auth that all items inherit if not set
- `.definitions.item.properties.response` which is an array of response types

This adds Collection.Auth, Item.Responses and Items.Responses and a new concrete Response type.