### PR TITLE
Chrisnesbit1/add event support at the collection level (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,28 @@ auth := postman.CreateAuth(postman.Basic, postman.CreateAuthParam("username", "p
 v := postman.CreateVariable("env", "prod")
 ```
 
+### Event
+
+`Event` can be added to `Collection` and run against any `Item` in the entire `Collection`.
+
+```go
+scripts := []string{
+		`
+pm.test("Status code is 200", function () {
+	pm.response.to.have.status(200);
+});`,
+		`
+pm.test("Response time is less than 200ms", function () {
+    pm.expect(pm.response.responseTime).to.be.below(200);
+});`,
+}
+
+e := CreateEvent(EventType(EventType_Test), "text/javascript", scripts)
+```
+
 ## Current support
 
-For now, it does not offer support for `Response` and `Event` objects. Feel free to submit a pull request if you want to add support for one of those objects.
+For now, it does not offer support for `Response` object. Feel free to submit a pull request if you want to add support for one of those objects.
 
 |  Object            | v2.0.0 | v2.1.0 |
 | ------------------ | ------ | ------ |
@@ -159,6 +178,6 @@ For now, it does not offer support for `Response` and `Event` objects. Feel free
 | Item               | Yes    | Yes    |
 | Request            | Yes    | Yes    |
 | Response           | No     | No     |
-| Event              | No     | No     |
+| Event              | Yes    | Yes    |
 | Variable           | Yes    | Yes    |
 | Auth               | Yes    | Yes    |

--- a/event.go
+++ b/event.go
@@ -1,0 +1,35 @@
+package postman
+
+// EventType is an enum type for an Event's `Listen` field.
+type EventType string
+
+const (
+	// EventTypePreRequestScript is the enum value for a Pre-Request Script that will run against all `Item` in a `Collection`
+	EventTypePreRequestScript string = "prerequest"
+	// EventTypeTest is the enum value for Tests that will run against all `Item` in a `Collection`
+	EventTypeTest string = "test"
+)
+
+// EventScript is a script (or group of scripts) that are run against a given `Item`.
+type EventScript struct {
+	ScriptType string   `json:"type"`
+	ScriptText []string `json:"exec"`
+}
+
+// A Event is a Pre-request Script or a Test that can be run post-request.
+type Event struct {
+	Listen EventType   `json:"listen"`
+	Script EventScript `json:"script"`
+}
+
+// CreateEvent creates a new Variable of type string.
+// "text/javascript"
+func CreateEvent(eventType EventType, scriptType string, scripts []string) *Event {
+	return &Event{
+		Listen: eventType,
+		Script: EventScript{
+			ScriptType: scriptType,
+			ScriptText: scripts,
+		},
+	}
+}

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,69 @@
+package postman
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateEventForPreRequestScript(t *testing.T) {
+	scripts := []string{
+		"",
+	}
+
+	//test the CreateEvent method
+	testEvent := CreateEvent(EventType(EventTypePreRequestScript), "text/javascript", scripts)
+
+	b, _ := json.Marshal(testEvent)
+	testEventJSON := string(b)
+
+	//expected outcome
+	expectedEvent := &Event{
+		Listen: EventType(EventTypePreRequestScript),
+		Script: EventScript{
+			ScriptType: "text/javascript",
+			ScriptText: scripts,
+		},
+	}
+	a, _ := json.Marshal(expectedEvent)
+	expectedEventJSON := string(a)
+
+	//compare expected outcome with CreateEvent response
+	assert.Equal(t, expectedEvent, testEvent)
+	assert.Equal(t, expectedEventJSON, testEventJSON)
+}
+
+func TestCreateEventForTests(t *testing.T) {
+	scripts := []string{
+		`
+pm.test("Status code is 200", function () {
+	pm.response.to.have.status(200);
+});`,
+		`
+pm.test("Response time is less than 200ms", function () {
+    pm.expect(pm.response.responseTime).to.be.below(200);
+});`,
+	}
+
+	//test the CreateEvent method
+	testEvent := CreateEvent(EventType(EventTypeTest), "text/javascript", scripts)
+
+	b, _ := json.Marshal(testEvent)
+	testEventJSON := string(b)
+
+	//expected outcome
+	expectedEvent := &Event{
+		Listen: EventType(EventTypeTest),
+		Script: EventScript{
+			ScriptType: "text/javascript",
+			ScriptText: scripts,
+		},
+	}
+	a, _ := json.Marshal(expectedEvent)
+	expectedEventJSON := string(a)
+
+	//compare expected outcome with CreateEvent response
+	assert.Equal(t, expectedEvent, testEvent)
+	assert.Equal(t, expectedEventJSON, testEventJSON)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rbretecher/go-postman-collection
+module github.com/chrisnesbit1/go-postman-collection
 
 go 1.13
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,11 +8,9 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This PR resolves https://github.com/rbretecher/go-postman-collection/issues/11.

It includes the following changes:
* add `Event` to postman collections (at the collection level, not individual `Item`s)
* unit tests
* add documentation for events to the README