### PR TITLE
Allow collection global auth to become null if not defined.

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -25,7 +25,7 @@ type Info struct {
 
 // Collection represents a Postman Collection.
 type Collection struct {
-	Auth      Auth        `json:"auth"`
+	Auth      *Auth       `json:"auth,omitempty"`
 	Info      Info        `json:"info"`
 	Items     []*Items    `json:"item"`
 	Events    []*Event    `json:"event,omitempty"`


### PR DESCRIPTION
With the current version of this module it is not possible to publish the generated collections via the Postman API as described here: https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a if the collection does not contain a global `auth` property. 

This leads to a collection with the structure of 
```
{
    "auth": {},
    "info": {
        "name": "...",
        "description": "...",
        "version": "",
        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
    },
    "item": []
}
```

which causes an error like this:

`failed with status 400: map[error:map[details:[auth: must be null auth: must have required property 'type' auth: must match exactly one schema in oneOf] message:Found 3 errors with the supplied collection. name:malformedRequestError]]`

So the API is expecting only an `auth` property if it is defined, meaning that the following payload is valid:

```
{
    "info": {
        "name": "...",
        "description": "...",
        "version": "",
        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
    },
    "item": []
}
```
Hence, the fix provided in this PR is making the `auth` property nullable in case that it is not defined.

Tested it with the API and the manual import via UI and proofed it to be working.
