### PR TITLE
Add a QueryFragment struct to be used by URL.Query

### DIFF
--- a/collection_test.go
+++ b/collection_test.go
@@ -475,18 +475,14 @@ func (suite *CollectionTestSuite) TestSimpleGETItem() {
 
 	defer file.Close()
 
-	m1 := map[string]interface{}{"key": "param1", "value": "value1"}
-	m2 := map[string]interface{}{"key": "param2", "value": "value2"}
-
-	var arrMaps []map[string]interface{}
-	arrMaps = append(arrMaps, m1)
-	arrMaps = append(arrMaps, m2)
-
 	pURL := URL{
 		Raw:      "https://test.com?a=3",
 		Protocol: "https",
 		Host:     []string{"test", "com"},
-		Query:    arrMaps,
+		Query: []*QueryFragment{
+			{Key: "param1", Value: "value1"},
+			{Key: "param2", Value: "value2"},
+		},
 	}
 
 	headers := []*Header{}

--- a/url.go
+++ b/url.go
@@ -10,18 +10,24 @@ import (
 // Raw contains the complete URL.
 type URL struct {
 	version   version
-	Raw       string      `json:"raw"`
-	Protocol  string      `json:"protocol,omitempty"`
-	Host      []string    `json:"host,omitempty"`
-	Path      []string    `json:"path,omitempty"`
-	Port      string      `json:"port,omitempty"`
-	Query     interface{} `json:"query,omitempty"`
-	Hash      string      `json:"hash,omitempty"`
-	Variables []*Variable `json:"variable,omitempty" mapstructure:"variable"`
+	Raw       string           `json:"raw"`
+	Protocol  string           `json:"protocol,omitempty"`
+	Host      []string         `json:"host,omitempty"`
+	Path      []string         `json:"path,omitempty"`
+	Port      string           `json:"port,omitempty"`
+	Query     []*QueryFragment `json:"query,omitempty"`
+	Hash      string           `json:"hash,omitempty"`
+	Variables []*Variable      `json:"variable,omitempty" mapstructure:"variable"`
 }
 
 // mURL is used for marshalling/unmarshalling.
 type mURL URL
+
+type QueryFragment struct {
+	Key         string  `json:"key"`
+	Value       string  `json:"value"`
+	Description *string `json:"description"`
+}
 
 // String returns the raw version of the URL.
 func (u URL) String() string {

--- a/url_test.go
+++ b/url_test.go
@@ -104,6 +104,20 @@ func TestURLUnmarshalJSON(t *testing.T) {
 			nil,
 		},
 		{
+			"Successfully unmarshalling an URL with query as a struct",
+			[]byte("{\"raw\":\"http://www.google.fr\",\"query\":[{\"key\":\"param1\",\"value\":\"an-awesome-value\"}]}"),
+			URL{
+				Raw: "http://www.google.fr",
+				Query: []*QueryFragment{
+					{
+						Key:   "param1",
+						Value: "an-awesome-value",
+					},
+				},
+			},
+			nil,
+		},
+		{
 			"Failed to unmarshal an URL because of an unsupported type",
 			[]byte("not-a-valid-url"),
 			URL{},


### PR DESCRIPTION
This PR adds support for the Query objects which are listed in this format:
```json
"query": [
    {
        "key": "category",
        "value": "todo",
        "description": "..."
    },
]
```