### PR TITLE
fix: item.description must be of type Description

### DIFF
--- a/items.go
+++ b/items.go
@@ -6,11 +6,11 @@ import "encoding/json"
 // It can either be a request (Item) or a folder (ItemGroup).
 type Items struct {
 	// Common fields.
-	Name                    string      `json:"name"`
-	Description             string      `json:"description,omitempty"`
-	Variables               []*Variable `json:"variable,omitempty"`
-	Events                  []*Event    `json:"event,omitempty"`
-	ProtocolProfileBehavior interface{} `json:"protocolProfileBehavior,omitempty"`
+	Name                    string       `json:"name"`
+	Description             *Description `json:"description,omitempty"`
+	Variables               []*Variable  `json:"variable,omitempty"`
+	Events                  []*Event     `json:"event,omitempty"`
+	ProtocolProfileBehavior interface{}  `json:"protocolProfileBehavior,omitempty"`
 	// Fields specific to Item
 	ID        string      `json:"id,omitempty"`
 	Request   *Request    `json:"request,omitempty"`
@@ -22,25 +22,25 @@ type Items struct {
 
 // An Item is an entity which contain an actual HTTP request, and sample responses attached to it.
 type Item struct {
-	Name                    string      `json:"name"`
-	Description             string      `json:"description,omitempty"`
-	Variables               []*Variable `json:"variable,omitempty"`
-	Events                  []*Event    `json:"event,omitempty"`
-	ProtocolProfileBehavior interface{} `json:"protocolProfileBehavior,omitempty"`
-	ID                      string      `json:"id,omitempty"`
-	Request                 *Request    `json:"request,omitempty"`
-	Responses               []*Response `json:"response,omitempty"`
+	Name                    string       `json:"name"`
+	Description             *Description `json:"description,omitempty"`
+	Variables               []*Variable  `json:"variable,omitempty"`
+	Events                  []*Event     `json:"event,omitempty"`
+	ProtocolProfileBehavior interface{}  `json:"protocolProfileBehavior,omitempty"`
+	ID                      string       `json:"id,omitempty"`
+	Request                 *Request     `json:"request,omitempty"`
+	Responses               []*Response  `json:"response,omitempty"`
 }
 
 // A ItemGroup is an ordered set of requests.
 type ItemGroup struct {
-	Name                    string      `json:"name"`
-	Description             string      `json:"description,omitempty"`
-	Variables               []*Variable `json:"variable,omitempty"`
-	Events                  []*Event    `json:"event,omitempty"`
-	ProtocolProfileBehavior interface{} `json:"protocolProfileBehavior,omitempty"`
-	Items                   []*Items    `json:"item"`
-	Auth                    *Auth       `json:"auth,omitempty"`
+	Name                    string       `json:"name"`
+	Description             *Description `json:"description,omitempty"`
+	Variables               []*Variable  `json:"variable,omitempty"`
+	Events                  []*Event     `json:"event,omitempty"`
+	ProtocolProfileBehavior interface{}  `json:"protocolProfileBehavior,omitempty"`
+	Items                   []*Items     `json:"item"`
+	Auth                    *Auth        `json:"auth,omitempty"`
 }
 
 // CreateItem is a helper to create a new Item.

--- a/items_test.go
+++ b/items_test.go
@@ -130,7 +130,7 @@ func TestItemsMarshalJSON(t *testing.T) {
 func TestCreateItem(t *testing.T) {
 	c := CreateItem(Item{
 		Name:        "An item",
-		Description: "A description",
+		Description: &Description{Content: "A description"},
 		Variables: []*Variable{
 			{
 				Name:  "variable-name",
@@ -171,7 +171,7 @@ func TestCreateItem(t *testing.T) {
 		t,
 		&Items{
 			Name:        "An item",
-			Description: "A description",
+			Description: &Description{Content: "A description"},
 			Variables: []*Variable{
 				{
 					Name:  "variable-name",
@@ -214,7 +214,7 @@ func TestCreateItem(t *testing.T) {
 func TestCreateItemGroup(t *testing.T) {
 	c := CreateItemGroup(ItemGroup{
 		Name:        "An item",
-		Description: "A description",
+		Description: &Description{Content: "A description"},
 		Variables: []*Variable{
 			{
 				Name:  "variable-name",
@@ -252,7 +252,7 @@ func TestCreateItemGroup(t *testing.T) {
 		t,
 		&Items{
 			Name:        "An item",
-			Description: "A description",
+			Description: &Description{Content: "A description"},
 			Variables: []*Variable{
 				{
 					Name:  "variable-name",


### PR DESCRIPTION
Changes the type field `description` of `Item` to be of type `Description`, since in the docs / json schema it is defined as type Description.

Docs: https://learning.postman.com/collection-format/reference/item/
